### PR TITLE
Improve back-to-top button focus visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -377,13 +377,17 @@ a:hover, a:focus {
   right: 20px;
   z-index: 99;
   border: none;
-  outline: none;
   background-color: var(--primary-blue);
   color: white;
   cursor: pointer;
   padding: 15px;
   border-radius: 10px;
   font-size: 18px;
+}
+
+#back-to-top-btn:focus-visible {
+  outline: 3px solid var(--accent-red);
+  outline-offset: 2px;
 }
 
 #back-to-top-btn:hover {


### PR DESCRIPTION
## Summary
- Remove `outline: none` from back-to-top button to enable focus indicators
- Add `:focus-visible` styling so the back-to-top button displays a visible outline when focused

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a4e2b2370832eac16bdac37681cef