### PR TITLE
Add user-customizable links

### DIFF
--- a/custom-links.js
+++ b/custom-links.js
@@ -1,0 +1,66 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const container = document.getElementById('custom-links-container');
+  const form = document.getElementById('custom-link-form');
+  const nameInput = document.getElementById('custom-link-name');
+  const urlInput = document.getElementById('custom-link-url');
+  if (!container || !form || !nameInput || !urlInput) return;
+
+  const removeLabel = container.dataset.removeLabel || 'Remove';
+
+  function getLinks() {
+    try {
+      return JSON.parse(localStorage.getItem('customLinks')) || [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function saveLinks(links) {
+    localStorage.setItem('customLinks', JSON.stringify(links));
+  }
+
+  function renderLinks() {
+    const links = getLinks();
+    container.innerHTML = '';
+    links.forEach(function(link, index) {
+      const wrapper = document.createElement('span');
+      wrapper.className = 'custom-link-item';
+
+      const a = document.createElement('a');
+      a.href = link.url;
+      a.textContent = link.name;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.textContent = removeLabel;
+      removeBtn.className = 'remove-link';
+      removeBtn.addEventListener('click', function() {
+        const links = getLinks();
+        links.splice(index, 1);
+        saveLinks(links);
+        renderLinks();
+      });
+
+      wrapper.appendChild(a);
+      wrapper.appendChild(removeBtn);
+      container.appendChild(wrapper);
+    });
+  }
+
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    const name = nameInput.value.trim();
+    const url = urlInput.value.trim();
+    if (!name || !url) return;
+    const links = getLinks();
+    links.push({ name: name, url: url });
+    saveLinks(links);
+    nameInput.value = '';
+    urlInput.value = '';
+    renderLinks();
+  });
+
+  renderLinks();
+});

--- a/index.html
+++ b/index.html
@@ -35,6 +35,12 @@
           </tr>
         </thead>
         <tbody>
+          <tr id="custom-links-row">
+            <td class="province-name">Custom Links</td>
+            <td>
+              <div class="links-container" id="custom-links-container" data-remove-label="Remove"></div>
+            </td>
+          </tr>
           <tr>
             <td class="province-name">British Columbia</td>
             <td>
@@ -209,8 +215,13 @@
           </tr>
         </tbody>
       </table>
+      <form id="custom-link-form">
+        <input type="text" id="custom-link-name" placeholder="Link name" aria-label="Link name" required>
+        <input type="url" id="custom-link-url" placeholder="https://example.com" aria-label="Link URL" required>
+        <button type="submit">Add</button>
+      </form>
     </main>
-    
+
     <footer class="footer">
       <p>This dashboard provides quick access to health news across Canada from both official government sources and general news coverage.</p>
       <div class="last-updated">Last updated: March 14, 2025</div>
@@ -219,6 +230,7 @@
     </footer>
   </div>
   <button onclick="topFunction()" id="back-to-top-btn" title="Back to top" aria-label="Back to top">Back to top</button>
+  <script src="custom-links.js"></script>
   <script>
     //Get the button
     var mybutton = document.getElementById("back-to-top-btn");

--- a/index_fr.html
+++ b/index_fr.html
@@ -34,6 +34,12 @@
           </tr>
         </thead>
         <tbody>
+          <tr id="custom-links-row">
+            <td class="province-name">Liens personnalisés</td>
+            <td>
+              <div class="links-container" id="custom-links-container" data-remove-label="Supprimer"></div>
+            </td>
+          </tr>
           <tr>
             <td class="province-name">Colombie-Britannique</td>
             <td>
@@ -208,6 +214,11 @@
           </tr>
         </tbody>
       </table>
+      <form id="custom-link-form">
+        <input type="text" id="custom-link-name" placeholder="Nom du lien" aria-label="Nom du lien" required>
+        <input type="url" id="custom-link-url" placeholder="https://exemple.com" aria-label="URL du lien" required>
+        <button type="submit">Ajouter</button>
+      </form>
     </main>
     <footer class="footer">
       <p>Ce tableau de bord offre un accès rapide aux nouvelles sur la santé à travers le Canada, provenant de sources gouvernementales officielles et de la couverture médiatique générale.</p>
@@ -216,6 +227,7 @@
     </footer>
   </div>
   <button onclick="topFunction()" id="back-to-top-btn" title="Haut de page" aria-label="Haut de page">Haut de page</button>
+  <script src="custom-links.js"></script>
   <script>
     //Get the button
     var mybutton = document.getElementById("back-to-top-btn");

--- a/style.css
+++ b/style.css
@@ -218,6 +218,55 @@ td {
   flex-wrap: wrap;
 }
 
+#custom-link-form {
+  margin-top: 10px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+#custom-link-form input {
+  padding: 6px 8px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--border-radius-sm);
+  flex: 1;
+}
+
+#custom-link-form button {
+  background-color: var(--primary-green);
+  color: white;
+  border: none;
+  border-radius: var(--border-radius-sm);
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: var(--transition-default);
+}
+
+#custom-link-form button:hover {
+  background-color: var(--dark-blue);
+}
+
+.custom-link-item {
+  display: inline-flex;
+  align-items: center;
+}
+
+.remove-link {
+  margin-left: 4px;
+  background-color: var(--accent-red);
+  color: white;
+  border: none;
+  border-radius: var(--border-radius-sm);
+  cursor: pointer;
+  padding: 2px 6px;
+  font-size: 12px;
+  transition: var(--transition-default);
+}
+
+.remove-link:hover {
+  background-color: var(--accent-red-dark);
+}
+
 a {
   color: var(--primary-blue);
   text-decoration: none;
@@ -367,6 +416,14 @@ a:hover, a:focus {
   .home-button {
     top: 5px;
     left: 5px;
+  }
+
+  #custom-link-form {
+    flex-direction: column;
+  }
+
+  #custom-link-form button {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- Allow users to add and remove their own news links with local storage persistence
- Style the new custom link form and removal buttons
- Provide French translations for the customizable links section

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a564c5eb4832ea694fa3ef4228160