### PR TITLE
Add user-customizable links

### DIFF
--- a/custom-links.js
+++ b/custom-links.js
@@ -1,0 +1,164 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const editToggle = document.getElementById('edit-toggle');
+  const containers = document.querySelectorAll('.links-container');
+  const lang = document.documentElement.lang.startsWith('fr') ? 'fr' : 'en';
+
+  const text = {
+    en: {
+      edit: 'Edit',
+      done: 'Done',
+      add: 'Add',
+      reset: 'Reset',
+      name: 'Link name',
+      url: 'https://example.com',
+      type: 'Source type',
+      external: 'External',
+      official: 'Official',
+      remove: 'Remove'
+    },
+    fr: {
+      edit: 'Modifier',
+      done: 'Terminer',
+      add: 'Ajouter',
+      reset: 'Réinitialiser',
+      name: 'Nom du lien',
+      url: 'https://exemple.com',
+      type: 'Type de source',
+      external: 'Externe',
+      official: 'Officielle',
+      remove: 'Supprimer'
+    }
+  };
+
+  const labels = text[lang];
+  const defaultLinks = {};
+
+  containers.forEach(container => {
+    const name = container.closest('tr').querySelector('.province-name').textContent.trim();
+    const key = slug(name);
+    container.dataset.category = key;
+    const links = Array.from(container.querySelectorAll('a')).map(a => ({
+      text: a.textContent,
+      url: a.href,
+      className: a.className
+    }));
+    defaultLinks[key] = links;
+    const stored = getStoredLinks(key);
+    render(container, stored ? stored : links.slice());
+  });
+
+  if (editToggle) {
+    editToggle.textContent = labels.edit;
+    editToggle.addEventListener('click', () => {
+      document.body.classList.toggle('editing');
+      if (document.body.classList.contains('editing')) {
+        editToggle.textContent = labels.done;
+        containers.forEach(showEditControls);
+      } else {
+        editToggle.textContent = labels.edit;
+        containers.forEach(hideEditControls);
+      }
+    });
+  }
+
+  function slug(str) {
+    return str.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+  }
+
+  function getStoredLinks(category) {
+    try {
+      return JSON.parse(localStorage.getItem('links_' + category));
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function saveLinks(category, links) {
+    localStorage.setItem('links_' + category, JSON.stringify(links));
+  }
+
+  function render(container, links) {
+    container.innerHTML = '';
+    const category = container.dataset.category;
+    links.forEach((link, index) => {
+      const wrapper = document.createElement('span');
+      wrapper.className = 'link-wrapper';
+
+      const a = document.createElement('a');
+      a.href = link.url;
+      a.textContent = link.text;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      if (link.className) a.className = link.className;
+
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.className = 'remove-link';
+      removeBtn.textContent = '×';
+      removeBtn.title = labels.remove;
+      removeBtn.addEventListener('click', () => {
+        links.splice(index, 1);
+        saveLinks(category, links);
+        render(container, links);
+        showEditControls(container);
+      });
+
+      wrapper.appendChild(a);
+      wrapper.appendChild(removeBtn);
+      container.appendChild(wrapper);
+    });
+
+    if (document.body.classList.contains('editing')) {
+      showEditControls(container);
+    }
+  }
+
+  function showEditControls(container) {
+    const category = container.dataset.category;
+    if (!container.querySelector('.add-link-form')) {
+      const form = document.createElement('form');
+      form.className = 'add-link-form';
+      form.innerHTML = `
+        <input type="text" placeholder="${labels.name}" aria-label="${labels.name}" required>
+        <input type="url" placeholder="${labels.url}" aria-label="${labels.url}" required>
+        <select aria-label="${labels.type}">
+          <option value="google-link">${labels.external}</option>
+          <option value="official-link">${labels.official}</option>
+        </select>
+        <button type="submit">${labels.add}</button>
+        <button type="button" class="reset-btn">${labels.reset}</button>
+      `;
+      container.appendChild(form);
+
+      form.addEventListener('submit', e => {
+        e.preventDefault();
+        const nameInput = form.querySelector('input[type="text"]');
+        const urlInput = form.querySelector('input[type="url"]');
+        const typeSelect = form.querySelector('select');
+        const name = nameInput.value.trim();
+        const url = urlInput.value.trim();
+        if (!name || !url) return;
+        const links = getStoredLinks(category) || defaultLinks[category].slice();
+        links.push({ text: name, url: url, className: typeSelect.value });
+        saveLinks(category, links);
+        nameInput.value = '';
+        urlInput.value = '';
+        typeSelect.value = 'google-link';
+        render(container, links);
+        showEditControls(container);
+      });
+
+      form.querySelector('.reset-btn').addEventListener('click', () => {
+        localStorage.removeItem('links_' + category);
+        render(container, defaultLinks[category].slice());
+        showEditControls(container);
+      });
+    }
+  }
+
+  function hideEditControls(container) {
+    const form = container.querySelector('.add-link-form');
+    if (form) form.remove();
+  }
+});
+

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
       <div class="link-labels">
         <div class="link-label"><span class="link-dot dot-google"></span> External Sources</div>
         <div class="link-label"><span class="link-dot dot-official"></span> Official Sources</div>
+        <button id="edit-toggle" class="edit-toggle" aria-label="Edit links">Edit</button>
       </div>
     </header>
     
@@ -210,7 +211,7 @@
         </tbody>
       </table>
     </main>
-    
+
     <footer class="footer">
       <p>This dashboard provides quick access to health news across Canada from both official government sources and general news coverage.</p>
       <div class="last-updated">Last updated: March 14, 2025</div>
@@ -219,6 +220,7 @@
     </footer>
   </div>
   <button onclick="topFunction()" id="back-to-top-btn" title="Back to top" aria-label="Back to top">Back to top</button>
+  <script src="custom-links.js"></script>
   <script>
     //Get the button
     var mybutton = document.getElementById("back-to-top-btn");

--- a/index_fr.html
+++ b/index_fr.html
@@ -23,6 +23,7 @@
       <div class="link-labels">
         <div class="link-label"><span class="link-dot dot-google"></span> Sources externes</div>
         <div class="link-label"><span class="link-dot dot-official"></span> Sources officielles</div>
+        <button id="edit-toggle" class="edit-toggle" aria-label="Modifier les liens">Modifier</button>
       </div>
     </header>
     <main>
@@ -216,6 +217,7 @@
     </footer>
   </div>
   <button onclick="topFunction()" id="back-to-top-btn" title="Haut de page" aria-label="Haut de page">Haut de page</button>
+  <script src="custom-links.js"></script>
   <script>
     //Get the button
     var mybutton = document.getElementById("back-to-top-btn");

--- a/style.css
+++ b/style.css
@@ -105,6 +105,23 @@ header {
   box-shadow: var(--shadow-lg);
 }
 
+.edit-toggle {
+  background-color: var(--primary-blue);
+  color: white;
+  border: none;
+  border-radius: var(--border-radius-sm);
+  padding: 5px 10px;
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition: var(--transition-default);
+}
+
+.edit-toggle:hover {
+  background-color: var(--dark-blue);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
 h1 {
   color: var(--dark-blue);
   text-align: center;
@@ -216,6 +233,70 @@ td {
   display: flex;
   gap: 8px; /* Reduced from 10px */
   flex-wrap: wrap;
+}
+
+.link-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.remove-link {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  background-color: var(--accent-red);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 16px;
+  height: 16px;
+  line-height: 16px;
+  font-size: 12px;
+  cursor: pointer;
+  display: none;
+}
+
+body.editing .remove-link {
+  display: block;
+}
+
+.add-link-form {
+  display: flex;
+  gap: 5px;
+  flex-wrap: wrap;
+  margin-top: 5px;
+}
+
+.add-link-form input {
+  padding: 6px 8px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--border-radius-sm);
+  flex: 1;
+}
+
+.add-link-form select {
+  padding: 6px 8px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--border-radius-sm);
+  flex: 1;
+}
+
+.add-link-form button {
+  background-color: var(--primary-green);
+  color: white;
+  border: none;
+  border-radius: var(--border-radius-sm);
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: var(--transition-default);
+}
+
+.add-link-form .reset-btn {
+  background-color: var(--accent-red);
+}
+
+.add-link-form button:hover {
+  background-color: var(--dark-blue);
 }
 
 a {
@@ -368,6 +449,7 @@ a:hover, a:focus {
     top: 5px;
     left: 5px;
   }
+
 }
 
 #back-to-top-btn {


### PR DESCRIPTION
## Summary
- Move edit mode toggle to the header legend so it's accessible from the far right
- Let users pick external vs official when adding custom links to apply correct styling
- Style the new type selector and relocate edit button in both English and French pages

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a564c5eb4832ea694fa3ef4228160