### PR TITLE
Modernize health news dashboard usability

### DIFF
--- a/custom-links.js
+++ b/custom-links.js
@@ -1,9 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
   const editToggle = document.getElementById('edit-toggle');
   const containers = document.querySelectorAll('.links-container');
-  const backToTopBtn = document.getElementById("back-to-top-btn");
+  const backToTopBtn = document.getElementById('back-to-top-btn');
   const searchInput = document.getElementById('search-input');
+  const clearSearchBtn = document.getElementById('clear-search');
   const noResultsMsg = document.getElementById('no-results');
+  const resultCount = document.getElementById('result-count');
+  const customCount = document.getElementById('custom-count');
+  const tableRows = Array.from(document.querySelectorAll('tbody tr'));
+  const filterButtons = Array.from(document.querySelectorAll('[data-filter]'));
   const lang = document.documentElement.lang.startsWith('fr') ? 'fr' : 'en';
 
   const text = {
@@ -22,7 +27,17 @@ document.addEventListener('DOMContentLoaded', () => {
       removed: 'Link removed!',
       resetMsg: 'Links reset to default!',
       error: 'Error saving changes.',
-      noLinks: 'No links available.'
+      noLinks: 'No links available.',
+      clear: 'Clear',
+      filters: {
+        all: 'All jurisdictions',
+        provinces: 'Provinces',
+        territories: 'Territories',
+        national: 'Canada'
+      },
+      resultSummary: count => `${count} jurisdiction${count === 1 ? '' : 's'} shown`,
+      customSummary: count => `${count} customized section${count === 1 ? '' : 's'}`,
+      shortcutHint: 'Tip: press / to jump to search'
     },
     fr: {
       edit: 'Modifier',
@@ -39,21 +54,75 @@ document.addEventListener('DOMContentLoaded', () => {
       removed: 'Lien supprimé !',
       resetMsg: 'Liens réinitialisés !',
       error: 'Erreur lors de l\'enregistrement.',
-      noLinks: 'Aucun lien disponible.'
+      noLinks: 'Aucun lien disponible.',
+      clear: 'Effacer',
+      filters: {
+        all: 'Toutes les juridictions',
+        provinces: 'Provinces',
+        territories: 'Territoires',
+        national: 'Canada'
+      },
+      resultSummary: count => `${count} juridiction${count === 1 ? '' : 's'} affichée${count === 1 ? '' : 's'}`,
+      customSummary: count => `${count} section${count === 1 ? '' : 's'} personnalisée${count === 1 ? '' : 's'}`,
+      shortcutHint: 'Astuce : appuyez sur / pour aller à la recherche'
     }
   };
 
   const labels = text[lang];
   const defaultLinks = {};
+  let activeFilter = 'all';
 
-  // Back to top logic
+  const provinceAbbreviations = {
+    'alberta': ['ab'],
+    'british columbia': ['bc'],
+    'colombie-britannique': ['bc'],
+    'manitoba': ['mb'],
+    'new brunswick': ['nb'],
+    'nouveau-brunswick': ['nb'],
+    'newfoundland and labrador': ['nl'],
+    'terre-neuve-et-labrador': ['nl'],
+    'northwest territories': ['nt'],
+    'territoires du nord-ouest': ['nt'],
+    'nova scotia': ['ns'],
+    'nouvelle-écosse': ['ns'],
+    'nunavut': ['nu'],
+    'ontario': ['on'],
+    'prince edward island': ['pe', 'pei'],
+    'île-du-prince-édouard': ['pe', 'pei'],
+    'quebec': ['qc'],
+    'québec': ['qc'],
+    'saskatchewan': ['sk'],
+    'yukon': ['yt', 'yk'],
+    'canada': ['ca', 'can']
+  };
+
+  const rowGroups = {
+    'british columbia': 'provinces',
+    'colombie-britannique': 'provinces',
+    'alberta': 'provinces',
+    'saskatchewan': 'provinces',
+    'manitoba': 'provinces',
+    'ontario': 'provinces',
+    'quebec': 'provinces',
+    'québec': 'provinces',
+    'new brunswick': 'provinces',
+    'nouveau-brunswick': 'provinces',
+    'nova scotia': 'provinces',
+    'nouvelle-écosse': 'provinces',
+    'prince edward island': 'provinces',
+    'île-du-prince-édouard': 'provinces',
+    'newfoundland and labrador': 'provinces',
+    'terre-neuve-et-labrador': 'provinces',
+    'yukon': 'territories',
+    'northwest territories': 'territories',
+    'territoires du nord-ouest': 'territories',
+    'nunavut': 'territories',
+    'canada': 'national'
+  };
+
   if (backToTopBtn) {
     window.addEventListener('scroll', () => {
-      if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
-        backToTopBtn.classList.add('visible');
-      } else {
-        backToTopBtn.classList.remove('visible');
-      }
+      backToTopBtn.classList.toggle('visible', window.scrollY > 200);
     });
 
     backToTopBtn.addEventListener('click', () => {
@@ -61,58 +130,10 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  // Search logic
-  if (searchInput) {
-    const provinceAbbreviations = {
-      'alberta': ['ab'],
-      'british columbia': ['bc'],
-      'colombie-britannique': ['bc'],
-      'manitoba': ['mb'],
-      'new brunswick': ['nb'],
-      'nouveau-brunswick': ['nb'],
-      'newfoundland and labrador': ['nl'],
-      'terre-neuve-et-labrador': ['nl'],
-      'northwest territories': ['nt'],
-      'territoires du nord-ouest': ['nt'],
-      'nova scotia': ['ns'],
-      'nouvelle-écosse': ['ns'],
-      'nunavut': ['nu'],
-      'ontario': ['on'],
-      'prince edward island': ['pe', 'pei'],
-      'île-du-prince-édouard': ['pe', 'pei'],
-      'quebec': ['qc'],
-      'québec': ['qc'],
-      'saskatchewan': ['sk'],
-      'yukon': ['yt', 'yk'],
-      'canada': ['ca', 'can']
-    };
-
-    searchInput.addEventListener('input', (e) => {
-      const term = e.target.value.toLowerCase();
-      let hasVisibleRows = false;
-
-      document.querySelectorAll('tbody tr').forEach(row => {
-        const provinceName = row.querySelector('.province-name').textContent.toLowerCase();
-        const abbreviations = provinceAbbreviations[provinceName] || [];
-        const matchesAbbreviation = abbreviations.some(abbr => abbr.includes(term));
-
-        if (provinceName.includes(term) || matchesAbbreviation) {
-          row.classList.remove('hidden');
-          hasVisibleRows = true;
-        } else {
-          row.classList.add('hidden');
-        }
-      });
-
-      if (noResultsMsg) {
-        if (hasVisibleRows) {
-          noResultsMsg.classList.remove('visible');
-        } else {
-          noResultsMsg.classList.add('visible');
-        }
-      }
-    });
-  }
+  tableRows.forEach(row => {
+    const provinceName = row.querySelector('.province-name')?.textContent.trim().toLowerCase() || '';
+    row.dataset.group = rowGroups[provinceName] || 'provinces';
+  });
 
   containers.forEach(container => {
     const name = container.closest('tr').querySelector('.province-name').textContent.trim();
@@ -125,22 +146,71 @@ document.addEventListener('DOMContentLoaded', () => {
     }));
     defaultLinks[key] = links;
     const stored = getStoredLinks(key);
-    render(container, stored ? stored : links.slice());
+    render(container, stored || links.slice());
+  });
+
+  if (searchInput) {
+    searchInput.setAttribute('title', labels.shortcutHint);
+    searchInput.addEventListener('input', applyFilters);
+  }
+
+  if (clearSearchBtn && searchInput) {
+    clearSearchBtn.textContent = labels.clear;
+    clearSearchBtn.addEventListener('click', () => {
+      searchInput.value = '';
+      searchInput.focus();
+      applyFilters();
+    });
+  }
+
+  document.addEventListener('keydown', event => {
+    if (event.key !== '/' || !searchInput) return;
+
+    const target = event.target;
+    const isEditable = target instanceof HTMLElement && (
+      target.isContentEditable ||
+      ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName)
+    );
+
+    if (!isEditable) {
+      event.preventDefault();
+      searchInput.focus();
+      searchInput.select();
+    }
+  });
+
+  filterButtons.forEach(button => {
+    const filter = button.dataset.filter;
+    if (filter && labels.filters[filter]) {
+      button.textContent = labels.filters[filter];
+    }
+
+    button.addEventListener('click', () => {
+      activeFilter = filter || 'all';
+      filterButtons.forEach(btn => btn.setAttribute('aria-pressed', String(btn === button)));
+      applyFilters();
+    });
   });
 
   if (editToggle) {
     editToggle.textContent = labels.edit;
     editToggle.addEventListener('click', () => {
       document.body.classList.toggle('editing');
-      if (document.body.classList.contains('editing')) {
-        editToggle.textContent = labels.done;
-        containers.forEach(showEditControls);
-      } else {
-        editToggle.textContent = labels.edit;
-        containers.forEach(hideEditControls);
-      }
+      const isEditing = document.body.classList.contains('editing');
+      editToggle.textContent = isEditing ? labels.done : labels.edit;
+      editToggle.setAttribute('aria-pressed', String(isEditing));
+      containers.forEach(container => {
+        if (isEditing) {
+          showEditControls(container);
+        } else {
+          hideEditControls(container);
+        }
+      });
     });
   }
+
+  applyFilters();
+  updateCustomCount();
 
   function slug(str) {
     return str.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
@@ -148,19 +218,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function getStoredLinks(category) {
     try {
-      return JSON.parse(localStorage.getItem('links_' + category));
-    } catch (e) {
-      console.error("Failed to load links", e);
+      return JSON.parse(localStorage.getItem(`links_${category}`));
+    } catch (error) {
+      console.error('Failed to load links', error);
       return null;
     }
   }
 
   function saveLinks(category, links) {
     try {
-      localStorage.setItem('links_' + category, JSON.stringify(links));
+      localStorage.setItem(`links_${category}`, JSON.stringify(links));
+      updateCustomCount();
       return true;
-    } catch (e) {
-      console.error("Failed to save links", e);
+    } catch (error) {
+      console.error('Failed to save links', error);
       showToast(labels.error, 'error');
       return false;
     }
@@ -173,11 +244,13 @@ document.addEventListener('DOMContentLoaded', () => {
       toast.id = 'toast-notification';
       document.body.appendChild(toast);
     }
+
     toast.textContent = message;
     toast.className = `show ${type}`;
 
-    // Clear previous timeout if exists
-    if (toast.timeoutId) clearTimeout(toast.timeoutId);
+    if (toast.timeoutId) {
+      clearTimeout(toast.timeoutId);
+    }
 
     toast.timeoutId = setTimeout(() => {
       toast.className = toast.className.replace('show', '').trim();
@@ -187,6 +260,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function render(container, links) {
     container.innerHTML = '';
     const category = container.dataset.category;
+    const row = container.closest('tr');
 
     if (links.length === 0) {
       const emptyMsg = document.createElement('div');
@@ -210,22 +284,25 @@ document.addEventListener('DOMContentLoaded', () => {
         removeBtn.className = 'remove-link';
         removeBtn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>';
         removeBtn.title = labels.remove;
+        removeBtn.setAttribute('aria-label', `${labels.remove}: ${link.text}`);
         removeBtn.addEventListener('click', () => {
-          if (confirm(labels.remove + '?')) {
+          if (confirm(`${labels.remove}?`)) {
             links.splice(index, 1);
             if (saveLinks(category, links)) {
               showToast(labels.removed);
               render(container, links);
               showEditControls(container);
+              applyFilters();
             }
           }
         });
 
-        wrapper.appendChild(a);
-        wrapper.appendChild(removeBtn);
+        wrapper.append(a, removeBtn);
         container.appendChild(wrapper);
       });
     }
+
+    updateLinkCount(row, links.length);
 
     if (document.body.classList.contains('editing')) {
       showEditControls(container);
@@ -234,63 +311,115 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function showEditControls(container) {
     const category = container.dataset.category;
-    if (!container.querySelector('.add-link-form')) {
-      const form = document.createElement('form');
-      form.className = 'add-link-form';
-      form.innerHTML = `
-        <div class="form-row">
-          <input type="text" placeholder="${labels.name}" aria-label="${labels.name}" required>
-          <input type="url" placeholder="${labels.url}" aria-label="${labels.url}" required>
+    if (container.querySelector('.add-link-form')) return;
+
+    const form = document.createElement('form');
+    form.className = 'add-link-form';
+    form.innerHTML = `
+      <div class="form-row">
+        <input type="text" placeholder="${labels.name}" aria-label="${labels.name}" required>
+        <input type="url" placeholder="${labels.url}" aria-label="${labels.url}" required>
+      </div>
+      <div class="form-row">
+        <select aria-label="${labels.type}">
+          <option value="google-link">${labels.external}</option>
+          <option value="official-link">${labels.official}</option>
+        </select>
+        <div class="form-actions">
+          <button type="submit" class="add-btn">${labels.add}</button>
+          <button type="button" class="reset-btn">${labels.reset}</button>
         </div>
-        <div class="form-row">
-          <select aria-label="${labels.type}">
-            <option value="google-link">${labels.external}</option>
-            <option value="official-link">${labels.official}</option>
-          </select>
-          <div class="form-actions">
-            <button type="submit" class="add-btn">${labels.add}</button>
-            <button type="button" class="reset-btn">${labels.reset}</button>
-          </div>
-        </div>
-      `;
-      container.appendChild(form);
+      </div>
+    `;
+    container.appendChild(form);
 
-      form.addEventListener('submit', e => {
-        e.preventDefault();
-        const nameInput = form.querySelector('input[type="text"]');
-        const urlInput = form.querySelector('input[type="url"]');
-        const typeSelect = form.querySelector('select');
-        const name = nameInput.value.trim();
-        const url = urlInput.value.trim();
-        if (!name || !url) return;
+    form.addEventListener('submit', event => {
+      event.preventDefault();
+      const nameInput = form.querySelector('input[type="text"]');
+      const urlInput = form.querySelector('input[type="url"]');
+      const typeSelect = form.querySelector('select');
+      const name = nameInput.value.trim();
+      const url = urlInput.value.trim();
+      if (!name || !url) return;
 
-        const links = getStoredLinks(category) || defaultLinks[category].slice();
-        links.push({ text: name, url: url, className: typeSelect.value });
+      const links = getStoredLinks(category) || defaultLinks[category].slice();
+      links.push({ text: name, url, className: typeSelect.value });
 
-        if (saveLinks(category, links)) {
-          showToast(labels.saved);
-          nameInput.value = '';
-          urlInput.value = '';
-          typeSelect.value = 'google-link';
-          render(container, links);
-          showEditControls(container);
-        }
-      });
+      if (saveLinks(category, links)) {
+        showToast(labels.saved);
+        nameInput.value = '';
+        urlInput.value = '';
+        typeSelect.value = 'google-link';
+        render(container, links);
+        showEditControls(container);
+        applyFilters();
+      }
+    });
 
-      form.querySelector('.reset-btn').addEventListener('click', () => {
-        if (confirm(labels.reset + '?')) {
-          localStorage.removeItem('links_' + category);
-          showToast(labels.resetMsg);
-          render(container, defaultLinks[category].slice());
-          showEditControls(container);
-        }
-      });
-    }
+    form.querySelector('.reset-btn').addEventListener('click', () => {
+      if (confirm(`${labels.reset}?`)) {
+        localStorage.removeItem(`links_${category}`);
+        updateCustomCount();
+        showToast(labels.resetMsg);
+        render(container, defaultLinks[category].slice());
+        showEditControls(container);
+        applyFilters();
+      }
+    });
   }
 
   function hideEditControls(container) {
     const form = container.querySelector('.add-link-form');
     if (form) form.remove();
   }
-});
 
+  function updateLinkCount(row, count) {
+    if (!row) return;
+    let badge = row.querySelector('.link-count');
+    if (!badge) {
+      badge = document.createElement('span');
+      badge.className = 'link-count';
+      row.querySelector('.province-name')?.appendChild(badge);
+    }
+    badge.textContent = count;
+  }
+
+  function updateCustomCount() {
+    if (!customCount) return;
+    const customized = Object.keys(defaultLinks).filter(category => localStorage.getItem(`links_${category}`)).length;
+    customCount.textContent = labels.customSummary(customized);
+  }
+
+  function applyFilters() {
+    const term = searchInput ? searchInput.value.trim().toLowerCase() : '';
+    let visibleCount = 0;
+
+    tableRows.forEach(row => {
+      const provinceName = row.querySelector('.province-name')?.childNodes[0]?.textContent?.trim().toLowerCase()
+        || row.querySelector('.province-name')?.textContent.trim().toLowerCase()
+        || '';
+      const abbreviations = provinceAbbreviations[provinceName] || [];
+      const linkText = Array.from(row.querySelectorAll('.links-container a'))
+        .map(link => `${link.textContent} ${link.href}`.toLowerCase())
+        .join(' ');
+      const matchesSearch = !term || provinceName.includes(term) || abbreviations.some(abbr => abbr.includes(term)) || linkText.includes(term);
+      const matchesFilter = activeFilter === 'all' || row.dataset.group === activeFilter;
+      const isVisible = matchesSearch && matchesFilter;
+
+      row.classList.toggle('hidden', !isVisible);
+      if (isVisible) visibleCount += 1;
+    });
+
+    if (clearSearchBtn) {
+      clearSearchBtn.hidden = !term;
+    }
+
+    if (resultCount) {
+      resultCount.textContent = labels.resultSummary(visibleCount);
+    }
+
+    if (noResultsMsg) {
+      noResultsMsg.classList.toggle('visible', visibleCount === 0);
+    }
+  }
+});

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 </head>
 
 <body>
+  <a class="skip-link" href="#main-content">Skip to news table</a>
   <div class="container">
     <header>
       <a href="https://ifptrd.github.io" class="home-button" title="Home" aria-label="Go to home page">
@@ -27,15 +28,41 @@
       <div class="header-controls">
         <a href="index_fr.html" class="language-toggle" aria-label="Switch to French">FR</a>
       </div>
-      <h1>Health News</h1>
-      <div class="search-container">
-        <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
-          fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <circle cx="11" cy="11" r="8"></circle>
-          <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-        </svg>
-        <input type="text" id="search-input" class="search-input" placeholder="Search provinces..."
+      <div class="hero">
+        <div class="eyebrow">Canadian monitoring dashboard</div>
+        <h1>Health News</h1>
+        <p class="subtitle">Browse official updates and broader coverage by province, territory, or national source. Use the search box, quick filters, and edit mode to tailor the view to your workflow.</p>
+      </div>
+      <div class="status-bar" aria-live="polite">
+        <div class="status-card">
+          <span class="status-label">Visible now</span>
+          <span class="status-value" id="result-count">0 jurisdictions shown</span>
+        </div>
+        <div class="status-card">
+          <span class="status-label">Your customizations</span>
+          <span class="status-value" id="custom-count">0 customized sections</span>
+        </div>
+      </div>
+      <div class="search-panel">
+        <div class="search-row">
+          <div class="search-container">
+            <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
+              fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="11" cy="11" r="8"></circle>
+              <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+            </svg>
+            <input type="text" id="search-input" class="search-input" placeholder="Search provinces..."
           aria-label="Search provinces">
+            <button id="clear-search" class="search-action" type="button" hidden>Clear</button>
+          </div>
+        </div>
+        <div class="search-hint">Tip: press / to focus search instantly.</div>
+        <div class="filters" role="group" aria-label="Quick filters">
+          <button type="button" class="filter-chip" data-filter="all" aria-pressed="true">All jurisdictions</button>
+          <button type="button" class="filter-chip" data-filter="provinces" aria-pressed="false">Provinces</button>
+          <button type="button" class="filter-chip" data-filter="territories" aria-pressed="false">Territories</button>
+          <button type="button" class="filter-chip" data-filter="national" aria-pressed="false">Canada</button>
+        </div>
       </div>
       <div class="link-labels">
         <div class="link-label"><span class="link-dot dot-google"></span> External Sources</div>
@@ -44,8 +71,9 @@
       </div>
     </header>
 
-    <main>
+    <main id="main-content">
       <table>
+        <caption>Use search or quick filters to narrow the list. Link badges show the number of sources in each row.</caption>
         <thead>
           <tr>
             <th scope="col">Jurisdiction</th>

--- a/index_fr.html
+++ b/index_fr.html
@@ -15,6 +15,7 @@
 </head>
 
 <body>
+  <a class="skip-link" href="#main-content">Aller au tableau</a>
   <div class="container">
     <header>
       <a href="https://ifptrd.github.io" class="home-button" title="Accueil" aria-label="Aller à la page d'accueil">
@@ -27,15 +28,41 @@
       <div class="header-controls">
         <a href="index.html" class="language-toggle" aria-label="Switch to English">EN</a>
       </div>
-      <h1>Nouvelles sur la santé</h1>
-      <div class="search-container">
-        <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
-          fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <circle cx="11" cy="11" r="8"></circle>
-          <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-        </svg>
-        <input type="text" id="search-input" class="search-input" placeholder="Rechercher une province..."
+      <div class="hero">
+        <div class="eyebrow">Tableau de veille canadien</div>
+        <h1>Nouvelles sur la santé</h1>
+        <p class="subtitle">Parcourez les mises à jour officielles et la couverture générale par province, territoire ou source nationale. Utilisez la recherche, les filtres rapides et le mode modification pour adapter l'affichage à votre travail.</p>
+      </div>
+      <div class="status-bar" aria-live="polite">
+        <div class="status-card">
+          <span class="status-label">Affichage actuel</span>
+          <span class="status-value" id="result-count">0 juridiction affichée</span>
+        </div>
+        <div class="status-card">
+          <span class="status-label">Vos personnalisations</span>
+          <span class="status-value" id="custom-count">0 section personnalisée</span>
+        </div>
+      </div>
+      <div class="search-panel">
+        <div class="search-row">
+          <div class="search-container">
+            <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
+              fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="11" cy="11" r="8"></circle>
+              <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+            </svg>
+            <input type="text" id="search-input" class="search-input" placeholder="Rechercher une province..."
           aria-label="Rechercher une province">
+            <button id="clear-search" class="search-action" type="button" hidden>Effacer</button>
+          </div>
+        </div>
+        <div class="search-hint">Astuce : appuyez sur / pour activer la recherche.</div>
+        <div class="filters" role="group" aria-label="Filtres rapides">
+          <button type="button" class="filter-chip" data-filter="all" aria-pressed="true">Toutes les juridictions</button>
+          <button type="button" class="filter-chip" data-filter="provinces" aria-pressed="false">Provinces</button>
+          <button type="button" class="filter-chip" data-filter="territories" aria-pressed="false">Territoires</button>
+          <button type="button" class="filter-chip" data-filter="national" aria-pressed="false">Canada</button>
+        </div>
       </div>
       <div class="link-labels">
         <div class="link-label"><span class="link-dot dot-google"></span> Sources externes</div>
@@ -43,8 +70,9 @@
         <button id="edit-toggle" class="edit-toggle" aria-label="Modifier les liens">Modifier</button>
       </div>
     </header>
-    <main>
+    <main id="main-content">
       <table>
+        <caption>Utilisez la recherche ou les filtres rapides pour réduire la liste. Les pastilles indiquent le nombre de sources par ligne.</caption>
         <thead>
           <tr>
             <th scope="col">Juridiction</th>

--- a/style.css
+++ b/style.css
@@ -1,34 +1,26 @@
 :root {
-  /* Modern Color Palette */
-  --primary-blue: #0056b3;
-  /* Darker, more accessible blue */
-  --primary-blue-light: #e7f1ff;
-  --primary-blue-hover: #004494;
-
-  --primary-green: #198754;
-  /* Bootstrap success green */
-  --primary-green-light: #e8f5e9;
-  --primary-green-hover: #157347;
-
+  --primary-blue: #0b5fff;
+  --primary-blue-light: #edf3ff;
+  --primary-blue-hover: #0048cc;
+  --primary-green: #157347;
+  --primary-green-light: #ecf9f0;
+  --primary-green-hover: #0f5d38;
   --accent-red: #dc3545;
   --accent-red-hover: #bb2d3b;
-
-  --dark-text: #212529;
-  --light-text: #6c757d;
-  --border-color: #dee2e6;
-  --bg-body: #f8f9fa;
+  --dark-text: #1f2937;
+  --light-text: #6b7280;
+  --border-color: #dbe2ea;
+  --bg-body: #eef2f7;
   --bg-card: #ffffff;
-
-  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.05);
-  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
-  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
-
-  --radius-sm: 4px;
-  --radius-md: 8px;
-  --radius-lg: 12px;
-  --radius-pill: 50px;
-
-  --font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --bg-muted: #f8fafc;
+  --shadow-sm: 0 2px 8px rgba(15, 23, 42, 0.06);
+  --shadow-md: 0 10px 30px rgba(15, 23, 42, 0.1);
+  --shadow-lg: 0 18px 40px rgba(15, 23, 42, 0.12);
+  --radius-sm: 8px;
+  --radius-md: 14px;
+  --radius-lg: 24px;
+  --radius-pill: 999px;
+  --font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 }
 
 * {
@@ -37,85 +29,96 @@
   box-sizing: border-box;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   font-family: var(--font-family);
-  background-color: var(--bg-body);
+  background:
+    radial-gradient(circle at top, rgba(11, 95, 255, 0.09), transparent 30%),
+    var(--bg-body);
   color: var(--dark-text);
   line-height: 1.6;
-  padding: 10px;
+  padding: 16px;
   min-height: 100vh;
 }
 
+.skip-link {
+  position: absolute;
+  left: 16px;
+  top: -48px;
+  background: var(--dark-text);
+  color: #fff;
+  padding: 10px 14px;
+  border-radius: var(--radius-pill);
+  z-index: 1000;
+  text-decoration: none;
+}
+
+.skip-link:focus {
+  top: 16px;
+}
+
 .container {
-  max-width: 1100px;
+  max-width: 1180px;
   margin: 0 auto;
   background-color: var(--bg-card);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-md);
-  padding: 20px;
-  animation: fadeIn 0.5s ease-in-out;
+  padding: 24px;
+  animation: fadeIn 0.4s ease-in-out;
 }
 
 @keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
-/* Header Styles */
 header {
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom: 20px;
+  gap: 16px;
+  margin: -24px -24px 24px;
+  padding: 24px;
   position: sticky;
   top: 0;
   z-index: 100;
-  padding: 15px;
-  background: rgba(255, 255, 255, 0.9);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border-bottom: 1px solid var(--border-color);
-  margin-left: -20px;
-  margin-right: -20px;
-  margin-top: -20px;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border-bottom: 1px solid rgba(219, 226, 234, 0.9);
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-  box-shadow: var(--shadow-sm);
+}
+
+.header-controls,
+.home-button {
+  position: absolute;
+  top: 24px;
 }
 
 .header-controls {
-  position: absolute;
-  top: 20px;
-  right: 20px;
-  display: flex;
-  gap: 10px;
-  align-items: center;
+  right: 24px;
 }
 
 .home-button {
-  position: absolute;
-  top: 20px;
-  left: 20px;
-  width: 40px;
-  height: 40px;
+  left: 24px;
+  width: 42px;
+  height: 42px;
   display: flex;
   align-items: center;
   justify-content: center;
   background-color: var(--primary-blue-light);
   color: var(--primary-blue);
-  border-radius: var(--radius-md);
+  border-radius: 12px;
   transition: all 0.2s ease;
 }
 
-.home-button:hover {
+.home-button:hover,
+.home-button:focus-visible {
   background-color: var(--primary-blue);
-  color: white;
+  color: #fff;
   transform: translateY(-2px);
 }
 
@@ -124,71 +127,192 @@ header {
   height: 20px;
 }
 
+.language-toggle,
+.edit-toggle,
+.search-action,
+.filter-chip,
+button,
+a {
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
 .language-toggle {
   padding: 8px 16px;
   background-color: var(--dark-text);
-  color: white;
+  color: #fff;
   border-radius: var(--radius-pill);
   text-decoration: none;
-  font-weight: 600;
+  font-weight: 700;
   font-size: 0.9rem;
-  transition: all 0.2s ease;
 }
 
-.language-toggle:hover {
-  background-color: black;
+.language-toggle:hover,
+.language-toggle:focus-visible {
+  background-color: #111827;
   transform: translateY(-2px);
 }
 
-h1 {
-  font-size: 2rem;
-  font-weight: 700;
-  color: var(--dark-text);
-  margin: 5px 0;
+.hero {
   text-align: center;
-  letter-spacing: -0.5px;
+  display: grid;
+  gap: 10px;
+  max-width: 760px;
 }
 
-/* Search Input */
-.search-container {
-  margin-top: 15px;
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 6px 12px;
+  margin: 0 auto;
+  border-radius: var(--radius-pill);
+  background: var(--primary-blue-light);
+  color: var(--primary-blue);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+h1 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  line-height: 1.1;
+  letter-spacing: -0.04em;
+}
+
+.subtitle {
+  color: var(--light-text);
+  font-size: 1rem;
+}
+
+.status-bar {
   width: 100%;
-  max-width: 400px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.status-card {
+  background: var(--bg-muted);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 14px 16px;
+}
+
+.status-label {
+  display: block;
+  color: var(--light-text);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.status-value {
+  display: block;
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin-top: 4px;
+}
+
+.search-panel {
+  width: 100%;
+  display: grid;
+  gap: 14px;
+}
+
+.search-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  width: 100%;
+}
+
+.search-container {
+  flex: 1;
   position: relative;
+}
+
+.search-icon {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--light-text);
+  pointer-events: none;
 }
 
 .search-input {
   width: 100%;
-  padding: 10px 15px 10px 40px;
+  padding: 12px 52px 12px 42px;
   border: 1px solid var(--border-color);
   border-radius: var(--radius-pill);
-  font-size: 0.95rem;
-  transition: all 0.2s ease;
-  background-color: var(--bg-body);
+  font-size: 1rem;
+  background: var(--bg-muted);
 }
 
-.search-input:focus {
+.search-input:focus-visible,
+.edit-toggle:focus-visible,
+.language-toggle:focus-visible,
+.filter-chip:focus-visible,
+.search-action:focus-visible,
+a.google-link:focus-visible,
+a.official-link:focus-visible,
+.remove-link:focus-visible,
+.add-btn:focus-visible,
+.reset-btn:focus-visible,
+.home-button:focus-visible {
   outline: none;
-  border-color: var(--primary-blue);
-  box-shadow: 0 0 0 3px var(--primary-blue-light);
-  background-color: white;
+  box-shadow: 0 0 0 3px rgba(11, 95, 255, 0.18);
 }
 
-.search-icon {
+.search-action {
   position: absolute;
-  left: 12px;
+  right: 8px;
   top: 50%;
   transform: translateY(-50%);
-  color: var(--light-text);
-  pointer-events: none;
+  border: none;
+  background: transparent;
+  color: var(--primary-blue);
+  font-weight: 700;
+  padding: 6px 10px;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
 }
 
-/* Legend & Controls */
+.search-hint {
+  color: var(--light-text);
+  font-size: 0.86rem;
+}
+
+.filters {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+}
+
+.filter-chip {
+  border: 1px solid var(--border-color);
+  background: #fff;
+  color: var(--light-text);
+  border-radius: var(--radius-pill);
+  padding: 8px 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.filter-chip[aria-pressed='true'] {
+  background: var(--dark-text);
+  color: #fff;
+  border-color: var(--dark-text);
+}
+
 .link-labels {
   display: flex;
-  gap: 20px;
+  gap: 16px;
   align-items: center;
-  margin-top: 15px;
   flex-wrap: wrap;
   justify-content: center;
 }
@@ -196,7 +320,7 @@ h1 {
 .link-label {
   display: flex;
   align-items: center;
-  font-size: 0.9rem;
+  font-size: 0.92rem;
   color: var(--light-text);
   font-weight: 500;
 }
@@ -208,54 +332,55 @@ h1 {
   margin-right: 8px;
 }
 
-.dot-google {
-  background-color: var(--primary-blue);
-}
-
-.dot-official {
-  background-color: var(--primary-green);
-}
+.dot-google { background-color: var(--primary-blue); }
+.dot-official { background-color: var(--primary-green); }
 
 .edit-toggle {
   background-color: transparent;
   border: 1px solid var(--border-color);
   color: var(--light-text);
-  padding: 6px 16px;
+  padding: 8px 16px;
   border-radius: var(--radius-pill);
   cursor: pointer;
-  font-weight: 600;
-  font-size: 0.85rem;
-  transition: all 0.2s ease;
+  font-weight: 700;
+  font-size: 0.9rem;
 }
 
-.edit-toggle:hover {
-  background-color: var(--bg-body);
-  color: var(--dark-text);
-  border-color: var(--dark-text);
+.edit-toggle:hover,
+.filter-chip:hover,
+.search-action:hover {
+  transform: translateY(-1px);
 }
 
-/* Table/List Styles */
+main {
+  scroll-margin-top: 120px;
+}
+
 table {
   width: 100%;
   border-collapse: separate;
-  border-spacing: 0 8px;
-  /* Spacing between rows */
+  border-spacing: 0 12px;
+}
+
+caption {
+  text-align: left;
+  color: var(--light-text);
+  padding-bottom: 12px;
 }
 
 thead th {
   text-align: left;
-  padding: 0 20px 10px;
+  padding: 0 20px 8px;
   color: var(--light-text);
-  font-weight: 600;
+  font-weight: 700;
   text-transform: uppercase;
-  font-size: 0.8rem;
-  letter-spacing: 1px;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
 }
 
 tbody tr {
-  background-color: white;
+  background-color: #fff;
   box-shadow: var(--shadow-sm);
-  border-radius: var(--radius-md);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -264,22 +389,20 @@ tbody tr:hover {
   box-shadow: var(--shadow-md);
 }
 
-tbody tr.hidden {
-  display: none;
-}
+tbody tr.hidden { display: none; }
 
 td {
-  padding: 12px 15px;
+  padding: 16px 18px;
   vertical-align: top;
   border-top: 1px solid var(--border-color);
   border-bottom: 1px solid var(--border-color);
 }
 
 td:first-child {
+  width: 24%;
   border-left: 1px solid var(--border-color);
   border-top-left-radius: var(--radius-md);
   border-bottom-left-radius: var(--radius-md);
-  width: 25%;
 }
 
 td:last-child {
@@ -291,10 +414,27 @@ td:last-child {
 .province-name {
   font-weight: 700;
   color: var(--dark-text);
-  font-size: 1.1rem;
+  font-size: 1.05rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
-/* Link Styles */
+.link-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 28px;
+  padding: 0 8px;
+  border-radius: var(--radius-pill);
+  background: var(--bg-muted);
+  border: 1px solid var(--border-color);
+  color: var(--light-text);
+  font-size: 0.82rem;
+}
+
 .links-container {
   display: flex;
   flex-wrap: wrap;
@@ -309,12 +449,11 @@ td:last-child {
 a.google-link,
 a.official-link {
   display: inline-block;
-  padding: 6px 12px;
+  padding: 7px 12px;
   border-radius: var(--radius-pill);
   text-decoration: none;
-  font-size: 0.85rem;
-  font-weight: 500;
-  transition: all 0.2s ease;
+  font-size: 0.88rem;
+  font-weight: 600;
   border: 1px solid transparent;
 }
 
@@ -323,9 +462,10 @@ a.google-link {
   color: var(--primary-blue);
 }
 
-a.google-link:hover {
+a.google-link:hover,
+a.google-link:focus-visible {
   background-color: var(--primary-blue);
-  color: white;
+  color: #fff;
 }
 
 a.official-link {
@@ -333,227 +473,32 @@ a.official-link {
   color: var(--primary-green);
 }
 
-a.official-link:hover {
+a.official-link:hover,
+a.official-link:focus-visible {
   background-color: var(--primary-green);
-  color: white;
+  color: #fff;
 }
 
-/* Edit Mode Styles */
 .remove-link {
   position: absolute;
   top: -8px;
   right: -8px;
-  width: 20px;
-  height: 20px;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
   background-color: var(--accent-red);
-  color: white;
-  border: 2px solid white;
+  color: #fff;
+  border: 2px solid #fff;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   box-shadow: var(--shadow-sm);
-  transition: all 0.2s ease;
   z-index: 10;
   padding: 0;
   opacity: 0;
   visibility: hidden;
-  transform: scale(0.8);
-}
-
-body.editing .remove-link {
-  opacity: 1;
-  visibility: visible;
-  transform: scale(1);
-}
-
-.search-icon {
-  position: absolute;
-  left: 12px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--light-text);
-  pointer-events: none;
-}
-
-/* Legend & Controls */
-.link-labels {
-  display: flex;
-  gap: 20px;
-  align-items: center;
-  margin-top: 15px;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
-.link-label {
-  display: flex;
-  align-items: center;
-  font-size: 0.9rem;
-  color: var(--light-text);
-  font-weight: 500;
-}
-
-.link-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  margin-right: 8px;
-}
-
-.dot-google {
-  background-color: var(--primary-blue);
-}
-
-.dot-official {
-  background-color: var(--primary-green);
-}
-
-.edit-toggle {
-  background-color: transparent;
-  border: 1px solid var(--border-color);
-  color: var(--light-text);
-  padding: 6px 16px;
-  border-radius: var(--radius-pill);
-  cursor: pointer;
-  font-weight: 600;
-  font-size: 0.85rem;
-  transition: all 0.2s ease;
-}
-
-.edit-toggle:hover {
-  background-color: var(--bg-body);
-  color: var(--dark-text);
-  border-color: var(--dark-text);
-}
-
-/* Table/List Styles */
-table {
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 0 8px;
-  /* Spacing between rows */
-}
-
-thead th {
-  text-align: left;
-  padding: 0 20px 10px;
-  color: var(--light-text);
-  font-weight: 600;
-  text-transform: uppercase;
-  font-size: 0.8rem;
-  letter-spacing: 1px;
-}
-
-tbody tr {
-  background-color: white;
-  box-shadow: var(--shadow-sm);
-  border-radius: var(--radius-md);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-tbody tr:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-md);
-}
-
-tbody tr.hidden {
-  display: none;
-}
-
-td {
-  padding: 12px 15px;
-  vertical-align: top;
-  border-top: 1px solid var(--border-color);
-  border-bottom: 1px solid var(--border-color);
-}
-
-td:first-child {
-  border-left: 1px solid var(--border-color);
-  border-top-left-radius: var(--radius-md);
-  border-bottom-left-radius: var(--radius-md);
-  width: 25%;
-}
-
-td:last-child {
-  border-right: 1px solid var(--border-color);
-  border-top-right-radius: var(--radius-md);
-  border-bottom-right-radius: var(--radius-md);
-}
-
-.province-name {
-  font-weight: 700;
-  color: var(--dark-text);
-  font-size: 1.1rem;
-}
-
-/* Link Styles */
-.links-container {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.link-wrapper {
-  position: relative;
-  display: inline-flex;
-}
-
-a.google-link,
-a.official-link {
-  display: inline-block;
-  padding: 6px 12px;
-  border-radius: var(--radius-pill);
-  text-decoration: none;
-  font-size: 0.85rem;
-  font-weight: 500;
-  transition: all 0.2s ease;
-  border: 1px solid transparent;
-}
-
-a.google-link {
-  background-color: var(--primary-blue-light);
-  color: var(--primary-blue);
-}
-
-a.google-link:hover {
-  background-color: var(--primary-blue);
-  color: white;
-}
-
-a.official-link {
-  background-color: var(--primary-green-light);
-  color: var(--primary-green);
-}
-
-a.official-link:hover {
-  background-color: var(--primary-green);
-  color: white;
-}
-
-/* Edit Mode Styles */
-.remove-link {
-  position: absolute;
-  top: -8px;
-  right: -8px;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background-color: var(--accent-red);
-  color: white;
-  border: 2px solid white;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  box-shadow: var(--shadow-sm);
-  transition: all 0.2s ease;
-  z-index: 10;
-  padding: 0;
-  opacity: 0;
-  visibility: hidden;
-  transform: scale(0.8);
+  transform: scale(0.85);
 }
 
 body.editing .remove-link {
@@ -564,47 +509,33 @@ body.editing .remove-link {
 
 .remove-link:hover {
   background-color: var(--accent-red-hover);
-  transform: scale(1.1);
 }
 
 .add-link-form {
+  display: grid;
+  gap: 10px;
   width: 100%;
-  margin-top: 15px;
-  padding: 20px;
-  background-color: var(--bg-body);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border-color);
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.02);
-  animation: fadeIn 0.3s ease;
+  margin-top: 12px;
+  padding: 12px;
+  background: var(--bg-muted);
+  border: 1px dashed var(--border-color);
+  border-radius: 12px;
 }
 
 .form-row {
   display: flex;
   gap: 10px;
-  margin-bottom: 15px;
-}
-
-.form-row:last-child {
-  margin-bottom: 0;
+  flex-wrap: wrap;
 }
 
 .add-link-form input,
 .add-link-form select {
-  padding: 10px 12px;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  font-family: inherit;
-  font-size: 0.9rem;
   flex: 1;
-  background-color: white;
-  transition: border-color 0.2s, box-shadow 0.2s;
-}
-
-.add-link-form input:focus,
-.add-link-form select:focus {
-  outline: none;
-  border-color: var(--primary-blue);
-  box-shadow: 0 0 0 3px var(--primary-blue-light);
+  min-width: 180px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  background: #fff;
 }
 
 .form-actions {
@@ -612,190 +543,198 @@ body.editing .remove-link {
   gap: 10px;
 }
 
-.add-btn {
-  background-color: var(--primary-blue);
-  color: white;
+.add-btn,
+.reset-btn {
   border: none;
-  padding: 10px 20px;
-  border-radius: var(--radius-sm);
   cursor: pointer;
-  font-weight: 600;
-  transition: background-color 0.2s, transform 0.1s;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  border-radius: var(--radius-pill);
+  padding: 10px 14px;
+  font-weight: 700;
 }
 
-.add-btn:hover {
-  background-color: var(--primary-blue-hover);
-}
-
-.add-btn:active {
-  transform: translateY(1px);
+.add-btn {
+  background: var(--primary-blue);
+  color: #fff;
 }
 
 .reset-btn {
-  background-color: white;
-  color: var(--accent-red);
-  border: 1px solid var(--accent-red);
-  padding: 10px 20px;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  font-weight: 600;
-  transition: all 0.2s;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  background: #fff;
+  color: var(--dark-text);
+  border: 1px solid var(--border-color);
 }
 
-.reset-btn:hover {
-  background-color: var(--accent-red);
-  color: white;
-}
-
-/* Empty State */
+.empty-category-msg,
 .no-results {
-  text-align: center;
-  padding: 40px;
   color: var(--light-text);
-  font-style: italic;
-  display: none;
-  background-color: var(--bg-body);
+  background: var(--bg-muted);
+  border: 1px dashed var(--border-color);
   border-radius: var(--radius-md);
-  margin-top: 20px;
+  padding: 14px 16px;
+}
+
+.no-results {
+  display: none;
+  margin-top: 12px;
 }
 
 .no-results.visible {
   display: block;
-  animation: fadeIn 0.3s ease;
 }
 
-/* Footer */
 .footer {
-  margin-top: 20px;
-  text-align: center;
-  color: var(--light-text);
-  font-size: 0.9rem;
+  margin-top: 24px;
+  padding-top: 16px;
   border-top: 1px solid var(--border-color);
-  padding-top: 20px;
+  color: var(--light-text);
+  display: grid;
+  gap: 8px;
 }
 
 .last-updated {
-  display: inline-block;
-  margin-top: 10px;
-  padding: 4px 12px;
-  background-color: var(--bg-body);
-  border-radius: var(--radius-pill);
-  font-size: 0.8rem;
-  font-weight: 500;
+  font-weight: 700;
+  color: var(--dark-text);
 }
 
-/* Back to Top Button */
 #back-to-top-btn {
   position: fixed;
-  bottom: 30px;
-  right: 30px;
-  background-color: var(--dark-text);
-  color: white;
+  right: 20px;
+  bottom: 20px;
   border: none;
-  padding: 12px 20px;
+  background: var(--dark-text);
+  color: #fff;
+  padding: 12px 16px;
   border-radius: var(--radius-pill);
-  font-weight: 600;
-  cursor: pointer;
   box-shadow: var(--shadow-lg);
+  cursor: pointer;
   opacity: 0;
-  visibility: hidden;
-  transform: translateY(20px);
-  transition: all 0.3s ease;
-  z-index: 100;
+  pointer-events: none;
 }
 
 #back-to-top-btn.visible {
-  background-color: var(--dark-text);
-  color: white;
-  padding: 12px 24px;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+#toast-notification {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%) translateY(12px);
+  background: var(--dark-text);
+  color: #fff;
+  padding: 12px 16px;
   border-radius: var(--radius-pill);
   box-shadow: var(--shadow-lg);
   opacity: 0;
-  visibility: hidden;
-  transition: all 0.3s ease;
-  z-index: 1000;
-  font-weight: 500;
+  pointer-events: none;
 }
 
 #toast-notification.show {
   opacity: 1;
-  visibility: visible;
   transform: translateX(-50%) translateY(0);
 }
 
 #toast-notification.error {
-  background-color: var(--accent-red);
+  background: var(--accent-red);
 }
 
-/* Responsive Design */
-@media (max-width: 768px) {
+@media (max-width: 860px) {
   .container {
-    padding: 15px;
-  }
-
-  h1 {
-    font-size: 1.8rem;
+    padding: 18px;
   }
 
   header {
-    margin-left: -15px;
-    margin-right: -15px;
-    margin-top: -15px;
-    padding: 15px;
+    margin: -18px -18px 20px;
+    padding: 18px;
   }
 
-  .header-controls {
-    top: 15px;
-    right: 15px;
+  .status-bar {
+    grid-template-columns: 1fr;
   }
 
-  .home-button {
-    top: 15px;
-    left: 15px;
+  .search-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  table,
+  thead,
+  tbody,
+  th,
+  td,
+  tr {
+    display: block;
   }
 
   thead {
-    display: none;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
   }
 
   tbody tr {
-    display: block;
-    margin-bottom: 20px;
+    margin-bottom: 14px;
+    border-radius: var(--radius-md);
+    overflow: hidden;
   }
 
   td {
-    display: block;
-    width: 100% !important;
-    border: none;
-    padding: 15px;
+    border-left: 1px solid var(--border-color);
+    border-right: 1px solid var(--border-color);
+  }
+
+  td:first-child,
+  td:last-child {
+    width: 100%;
+    border-radius: 0;
   }
 
   td:first-child {
-    background-color: var(--bg-body);
-    border-bottom: 1px solid var(--border-color);
-    border-radius: var(--radius-md) var(--radius-md) 0 0;
+    border-top-left-radius: var(--radius-md);
+    border-top-right-radius: var(--radius-md);
   }
 
   td:last-child {
-    border-radius: 0 0 var(--radius-md) var(--radius-md);
+    border-bottom-left-radius: var(--radius-md);
+    border-bottom-right-radius: var(--radius-md);
+  }
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 10px;
   }
 
-  .form-row {
-    flex-direction: column;
+  .header-controls,
+  .home-button {
+    position: static;
   }
 
+  header {
+    padding-top: 16px;
+  }
+
+  .hero {
+    margin-top: 4px;
+  }
+
+  .link-labels,
+  .filters,
+  .form-row,
   .form-actions {
     width: 100%;
   }
 
-  .add-btn,
-  .reset-btn {
-    flex: 1;
+  .filters {
+    justify-content: flex-start;
+  }
+
+  .filter-chip,
+  .edit-toggle,
+  .language-toggle {
+    width: auto;
   }
 }


### PR DESCRIPTION
### Motivation
- Improve discoverability and quick scanning of provincial/national health sources with clearer header, status indicators and keyboard-friendly search. 
- Make the UI more usable on modern devices with updated visual hierarchy, stronger focus states, and clearer editing/feedback flows. 
- Add small accessibility and productivity improvements (skip link, `/` shortcut, quick filters, result counts) to speed regular monitoring workflows.

### Description
- Updated `index.html` and `index_fr.html` to add a hero area, skip-link navigation, live status cards (`#result-count`, `#custom-count`), quick filter chips, a clear-search button, improved search panel markup, and table captioning. 
- Rewrote `custom-links.js` to centralize behavior: filter groups, `applyFilters` (search + filter chips + link text), `/` keyboard shortcut to focus search, clear-search handling, per-row link-count badges, custom-section tracking, improved localStorage key handling, and more robust toast/ARIA attributes. 
- Redesigned `style.css` with a refreshed palette, card-based layout, enhanced responsive rules (mobile-friendly table stacking), improved focus/hover states, skip-link styles, and form/control spacing for better usability. 
- Changes preserve existing functionality (editable links via localStorage) while adding feedback hooks and accessibility improvements.

### Testing
- Ran `node --check custom-links.js` to validate JavaScript syntax, which succeeded. 
- Parsed `index.html` and `index_fr.html` with Python's `html.parser` to ensure the modified markup is well-formed, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb3e07a10c832e98cf45b6447d6490)