### PR TITLE
Overhaul health news dashboard for faster browsing

### DIFF
--- a/custom-links.js
+++ b/custom-links.js
@@ -142,7 +142,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const links = Array.from(container.querySelectorAll('a')).map(a => ({
       text: a.textContent,
       url: a.href,
-      className: a.className
+      className: a.className,
+      ariaLabel: a.getAttribute('aria-label')
     }));
     defaultLinks[key] = links;
     const stored = getStoredLinks(key);
@@ -278,6 +279,7 @@ document.addEventListener('DOMContentLoaded', () => {
         a.target = '_blank';
         a.rel = 'noopener noreferrer';
         if (link.className) a.className = link.className;
+        if (link.ariaLabel) a.setAttribute('aria-label', link.ariaLabel);
 
         const removeBtn = document.createElement('button');
         removeBtn.type = 'button';

--- a/index.html
+++ b/index.html
@@ -43,6 +43,8 @@
           <span class="status-value" id="custom-count">0 customized sections</span>
         </div>
       </div>
+    </header>
+    <section class="command-bar" aria-label="News directory controls">
       <div class="search-panel">
         <div class="search-row">
           <div class="search-container">
@@ -69,7 +71,7 @@
         <div class="link-label"><span class="link-dot dot-official"></span> Official Sources</div>
         <button id="edit-toggle" class="edit-toggle" aria-label="Edit links">Edit</button>
       </div>
-    </header>
+    </section>
 
     <main id="main-content">
       <table>

--- a/index_fr.html
+++ b/index_fr.html
@@ -43,6 +43,8 @@
           <span class="status-value" id="custom-count">0 section personnalisée</span>
         </div>
       </div>
+    </header>
+    <section class="command-bar" aria-label="Commandes du répertoire de nouvelles">
       <div class="search-panel">
         <div class="search-row">
           <div class="search-container">
@@ -69,7 +71,7 @@
         <div class="link-label"><span class="link-dot dot-official"></span> Sources officielles</div>
         <button id="edit-toggle" class="edit-toggle" aria-label="Modifier les liens">Modifier</button>
       </div>
-    </header>
+    </section>
     <main id="main-content">
       <table>
         <caption>Utilisez la recherche ou les filtres rapides pour réduire la liste. Les pastilles indiquent le nombre de sources par ligne.</caption>

--- a/style.css
+++ b/style.css
@@ -1,740 +1,493 @@
 :root {
-  --primary-blue: #0b5fff;
-  --primary-blue-light: #edf3ff;
-  --primary-blue-hover: #0048cc;
-  --primary-green: #157347;
-  --primary-green-light: #ecf9f0;
-  --primary-green-hover: #0f5d38;
-  --accent-red: #dc3545;
-  --accent-red-hover: #bb2d3b;
-  --dark-text: #1f2937;
-  --light-text: #6b7280;
-  --border-color: #dbe2ea;
-  --bg-body: #eef2f7;
-  --bg-card: #ffffff;
-  --bg-muted: #f8fafc;
-  --shadow-sm: 0 2px 8px rgba(15, 23, 42, 0.06);
-  --shadow-md: 0 10px 30px rgba(15, 23, 42, 0.1);
-  --shadow-lg: 0 18px 40px rgba(15, 23, 42, 0.12);
-  --radius-sm: 8px;
-  --radius-md: 14px;
-  --radius-lg: 24px;
-  --radius-pill: 999px;
-  --font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --ink: #17222f;
+  --ink-soft: #5d6b7a;
+  --navy: #12324a;
+  --blue: #1769e0;
+  --blue-soft: #eaf2ff;
+  --green: #087a5b;
+  --green-soft: #e7f7f1;
+  --red: #c93648;
+  --surface: #ffffff;
+  --surface-soft: #f5f7fa;
+  --line: #dce3ea;
+  --shadow: 0 16px 40px rgba(18, 50, 74, 0.09);
+  --shadow-soft: 0 4px 14px rgba(18, 50, 74, 0.07);
+  --radius: 16px;
+  --radius-sm: 10px;
+  --pill: 999px;
+  --font: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
+* { box-sizing: border-box; margin: 0; padding: 0; }
 
-html {
-  scroll-behavior: smooth;
-}
+html { scroll-behavior: smooth; }
 
 body {
-  font-family: var(--font-family);
-  background:
-    radial-gradient(circle at top, rgba(11, 95, 255, 0.09), transparent 30%),
-    var(--bg-body);
-  color: var(--dark-text);
-  line-height: 1.6;
-  padding: 16px;
   min-height: 100vh;
+  padding: 20px;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 8% 0%, rgba(23, 105, 224, 0.12), transparent 28rem),
+    #eef2f5;
+  font-family: var(--font);
+  line-height: 1.45;
 }
 
+button,
+input,
+select { font: inherit; }
+
+button,
+a { transition: color .18s ease, background-color .18s ease, border-color .18s ease, box-shadow .18s ease, transform .18s ease; }
+
 .skip-link {
-  position: absolute;
-  left: 16px;
-  top: -48px;
-  background: var(--dark-text);
-  color: #fff;
-  padding: 10px 14px;
-  border-radius: var(--radius-pill);
+  position: fixed;
+  top: -60px;
+  left: 20px;
   z-index: 1000;
+  padding: 10px 16px;
+  border-radius: var(--pill);
+  background: var(--navy);
+  color: #fff;
+  font-weight: 700;
   text-decoration: none;
 }
 
-.skip-link:focus {
-  top: 16px;
-}
+.skip-link:focus { top: 12px; }
 
 .container {
-  max-width: 1180px;
+  width: min(1440px, 100%);
   margin: 0 auto;
-  background-color: var(--bg-card);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-md);
-  padding: 24px;
-  animation: fadeIn 0.4s ease-in-out;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; transform: translateY(10px); }
-  to { opacity: 1; transform: translateY(0); }
+  overflow: clip;
+  border: 1px solid rgba(220, 227, 234, .9);
+  border-radius: 22px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
 }
 
 header {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 16px;
-  margin: -24px -24px 24px;
-  padding: 24px;
-  position: sticky;
-  top: 0;
-  z-index: 100;
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
-  border-bottom: 1px solid rgba(219, 226, 234, 0.9);
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-}
-
-.header-controls,
-.home-button {
-  position: absolute;
-  top: 24px;
-}
-
-.header-controls {
-  right: 24px;
-}
-
-.home-button {
-  left: 24px;
-  width: 42px;
-  height: 42px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: var(--primary-blue-light);
-  color: var(--primary-blue);
-  border-radius: 12px;
-  transition: all 0.2s ease;
-}
-
-.home-button:hover,
-.home-button:focus-visible {
-  background-color: var(--primary-blue);
-  color: #fff;
-  transform: translateY(-2px);
-}
-
-.home-icon {
-  width: 20px;
-  height: 20px;
-}
-
-.language-toggle,
-.edit-toggle,
-.search-action,
-.filter-chip,
-button,
-a {
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-}
-
-.language-toggle {
-  padding: 8px 16px;
-  background-color: var(--dark-text);
-  color: #fff;
-  border-radius: var(--radius-pill);
-  text-decoration: none;
-  font-weight: 700;
-  font-size: 0.9rem;
-}
-
-.language-toggle:hover,
-.language-toggle:focus-visible {
-  background-color: #111827;
-  transform: translateY(-2px);
-}
-
-.hero {
-  text-align: center;
-  display: grid;
-  gap: 10px;
-  max-width: 760px;
-}
-
-.eyebrow {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 6px 12px;
-  margin: 0 auto;
-  border-radius: var(--radius-pill);
-  background: var(--primary-blue-light);
-  color: var(--primary-blue);
-  font-size: 0.82rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-h1 {
-  font-size: clamp(2rem, 4vw, 2.8rem);
-  line-height: 1.1;
-  letter-spacing: -0.04em;
-}
-
-.subtitle {
-  color: var(--light-text);
-  font-size: 1rem;
-}
-
-.status-bar {
-  width: 100%;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.status-card {
-  background: var(--bg-muted);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  padding: 14px 16px;
-}
-
-.status-label {
-  display: block;
-  color: var(--light-text);
-  font-size: 0.82rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-
-.status-value {
-  display: block;
-  font-size: 1.1rem;
-  font-weight: 700;
-  margin-top: 4px;
-}
-
-.search-panel {
-  width: 100%;
-  display: grid;
-  gap: 14px;
-}
-
-.search-row {
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  width: 100%;
-}
-
-.search-container {
-  flex: 1;
   position: relative;
+  min-height: 176px;
+  padding: 34px clamp(80px, 9vw, 150px) 26px;
+  overflow: hidden;
+  color: #fff;
+  background:
+    radial-gradient(circle at 82% 5%, rgba(94, 211, 190, .22), transparent 17rem),
+    linear-gradient(128deg, #102f46 0%, #164b6a 68%, #126c73 100%);
 }
 
-.search-icon {
+header::after {
+  content: '';
   position: absolute;
-  left: 14px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--light-text);
+  right: -60px;
+  bottom: -120px;
+  width: 300px;
+  height: 300px;
+  border: 52px solid rgba(255, 255, 255, .04);
+  border-radius: 50%;
   pointer-events: none;
 }
 
-.search-input {
-  width: 100%;
-  padding: 12px 52px 12px 42px;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-pill);
-  font-size: 1rem;
-  background: var(--bg-muted);
+.home-button,
+.header-controls {
+  position: absolute;
+  z-index: 2;
+  top: 28px;
 }
 
-.search-input:focus-visible,
-.edit-toggle:focus-visible,
-.language-toggle:focus-visible,
-.filter-chip:focus-visible,
-.search-action:focus-visible,
-a.google-link:focus-visible,
-a.official-link:focus-visible,
-.remove-link:focus-visible,
-.add-btn:focus-visible,
-.reset-btn:focus-visible,
-.home-button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(11, 95, 255, 0.18);
+.home-button {
+  left: 30px;
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, .22);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, .1);
+  color: #fff;
 }
+
+.home-button:hover,
+.home-button:focus-visible { background: #fff; color: var(--navy); transform: translateY(-1px); }
+.home-icon { width: 19px; height: 19px; }
+.header-controls { right: 30px; }
+
+.language-toggle {
+  display: inline-flex;
+  align-items: center;
+  min-height: 42px;
+  padding: 0 16px;
+  border: 1px solid rgba(255, 255, 255, .22);
+  border-radius: var(--pill);
+  background: rgba(255, 255, 255, .1);
+  color: #fff;
+  font-size: .85rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.language-toggle:hover,
+.language-toggle:focus-visible { background: #fff; color: var(--navy); transform: translateY(-1px); }
+
+.hero { position: relative; z-index: 1; max-width: min(820px, calc(100% - 360px)); }
+
+.eyebrow {
+  margin-bottom: 8px;
+  color: #8fe5d4;
+  font-size: .73rem;
+  font-weight: 800;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+h1 { font-size: clamp(2rem, 4vw, 3rem); line-height: 1.04; letter-spacing: -.045em; }
+
+.subtitle {
+  max-width: 730px;
+  margin-top: 10px;
+  color: rgba(255, 255, 255, .76);
+  font-size: .94rem;
+}
+
+.status-bar {
+  position: absolute;
+  z-index: 2;
+  right: clamp(80px, 6vw, 110px);
+  bottom: 29px;
+  display: flex;
+  gap: 8px;
+}
+
+.status-card {
+  min-width: 150px;
+  padding: 10px 13px;
+  border: 1px solid rgba(255, 255, 255, .16);
+  border-radius: 12px;
+  background: rgba(6, 31, 47, .28);
+  backdrop-filter: blur(8px);
+}
+
+.status-label { display: block; color: rgba(255,255,255,.58); font-size: .67rem; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; }
+.status-value { display: block; margin-top: 2px; color: #fff; font-size: .88rem; font-weight: 750; }
+
+.command-bar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 22px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(255, 255, 255, .96);
+  box-shadow: 0 4px 16px rgba(18, 50, 74, .05);
+  backdrop-filter: blur(14px);
+}
+
+.search-panel { display: flex; min-width: 0; align-items: center; gap: 12px; }
+.search-row { width: min(340px, 100%); flex: 0 1 340px; }
+.search-container { position: relative; width: 100%; }
+.search-icon { position: absolute; top: 50%; left: 13px; color: var(--ink-soft); transform: translateY(-50%); pointer-events: none; }
+
+.search-input {
+  width: 100%;
+  height: 40px;
+  padding: 0 55px 0 38px;
+  border: 1px solid var(--line);
+  border-radius: var(--pill);
+  background: var(--surface-soft);
+  color: var(--ink);
+  outline: none;
+}
+
+.search-input::placeholder { color: #7c8997; }
+.search-input:focus { border-color: var(--blue); background: #fff; box-shadow: 0 0 0 3px rgba(23, 105, 224, .13); }
 
 .search-action {
   position: absolute;
-  right: 8px;
   top: 50%;
-  transform: translateY(-50%);
-  border: none;
+  right: 7px;
+  padding: 5px 8px;
+  border: 0;
+  border-radius: var(--pill);
   background: transparent;
-  color: var(--primary-blue);
-  font-weight: 700;
-  padding: 6px 10px;
-  border-radius: var(--radius-pill);
+  color: var(--blue);
+  font-size: .75rem;
+  font-weight: 800;
   cursor: pointer;
+  transform: translateY(-50%);
 }
 
-.search-hint {
-  color: var(--light-text);
-  font-size: 0.86rem;
-}
+.search-action:hover { background: var(--blue-soft); }
+.search-hint { display: none; }
+.filters { display: flex; min-width: max-content; gap: 5px; }
 
-.filters {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-}
-
-.filter-chip {
-  border: 1px solid var(--border-color);
-  background: #fff;
-  color: var(--light-text);
-  border-radius: var(--radius-pill);
-  padding: 8px 14px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.filter-chip[aria-pressed='true'] {
-  background: var(--dark-text);
-  color: #fff;
-  border-color: var(--dark-text);
-}
-
-.link-labels {
-  display: flex;
-  gap: 16px;
-  align-items: center;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
-.link-label {
-  display: flex;
-  align-items: center;
-  font-size: 0.92rem;
-  color: var(--light-text);
-  font-weight: 500;
-}
-
-.link-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  margin-right: 8px;
-}
-
-.dot-google { background-color: var(--primary-blue); }
-.dot-official { background-color: var(--primary-green); }
-
+.filter-chip,
 .edit-toggle {
-  background-color: transparent;
-  border: 1px solid var(--border-color);
-  color: var(--light-text);
-  padding: 8px 16px;
-  border-radius: var(--radius-pill);
+  min-height: 36px;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--pill);
+  background: #fff;
+  color: var(--ink-soft);
+  font-size: .78rem;
+  font-weight: 750;
   cursor: pointer;
-  font-weight: 700;
-  font-size: 0.9rem;
 }
 
-.edit-toggle:hover,
 .filter-chip:hover,
-.search-action:hover {
-  transform: translateY(-1px);
+.edit-toggle:hover { border-color: #aebbc8; color: var(--ink); background: var(--surface-soft); }
+.filter-chip[aria-pressed='true'] { border-color: var(--navy); background: var(--navy); color: #fff; }
+
+.link-labels { display: flex; align-items: center; justify-content: flex-end; gap: 12px; }
+.link-label { display: inline-flex; align-items: center; color: var(--ink-soft); font-size: .73rem; font-weight: 650; white-space: nowrap; }
+.link-dot { width: 7px; height: 7px; margin-right: 5px; border-radius: 50%; }
+.dot-google { background: var(--blue); }
+.dot-official { background: var(--green); }
+.edit-toggle { margin-left: 2px; color: var(--navy); }
+body.editing .edit-toggle { border-color: var(--blue); background: var(--blue); color: #fff; }
+
+main { padding: 20px 22px 8px; scroll-margin-top: 76px; }
+
+table,
+tbody { display: block; width: 100%; }
+
+caption,
+thead {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
-main {
-  scroll-margin-top: 120px;
-}
-
-table {
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 0 12px;
-}
-
-caption {
-  text-align: left;
-  color: var(--light-text);
-  padding-bottom: 12px;
-}
-
-thead th {
-  text-align: left;
-  padding: 0 20px 8px;
-  color: var(--light-text);
-  font-weight: 700;
-  text-transform: uppercase;
-  font-size: 0.78rem;
-  letter-spacing: 0.08em;
+tbody {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
 }
 
 tbody tr {
-  background-color: #fff;
-  box-shadow: var(--shadow-sm);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: grid;
+  grid-template-columns: minmax(142px, 24%) 1fr;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: #fff;
+  box-shadow: var(--shadow-soft);
 }
 
-tbody tr:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-md);
-}
-
+tbody tr:hover { border-color: #bbc9d5; box-shadow: 0 7px 20px rgba(18, 50, 74, .1); transform: translateY(-1px); }
 tbody tr.hidden { display: none; }
 
-td {
-  padding: 16px 18px;
-  vertical-align: top;
-  border-top: 1px solid var(--border-color);
-  border-bottom: 1px solid var(--border-color);
-}
-
-td:first-child {
-  width: 24%;
-  border-left: 1px solid var(--border-color);
-  border-top-left-radius: var(--radius-md);
-  border-bottom-left-radius: var(--radius-md);
-}
-
-td:last-child {
-  border-right: 1px solid var(--border-color);
-  border-top-right-radius: var(--radius-md);
-  border-bottom-right-radius: var(--radius-md);
-}
+td { display: block; min-width: 0; padding: 12px; vertical-align: top; }
+td:first-child { display: flex; align-items: flex-start; border-right: 1px solid var(--line); background: linear-gradient(145deg, #f8fafb, #f1f5f7); }
 
 .province-name {
-  font-weight: 700;
-  color: var(--dark-text);
-  font-size: 1.05rem;
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
+  position: relative;
+  width: 100%;
+  padding-right: 32px;
+  color: var(--navy);
+  font-size: .88rem;
+  font-weight: 800;
+  line-height: 1.3;
 }
 
 .link-count {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 28px;
-  height: 28px;
-  padding: 0 8px;
-  border-radius: var(--radius-pill);
-  background: var(--bg-muted);
-  border: 1px solid var(--border-color);
-  color: var(--light-text);
-  font-size: 0.82rem;
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: grid;
+  min-width: 23px;
+  height: 23px;
+  padding: 0 6px;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: var(--pill);
+  background: #fff;
+  color: var(--ink-soft);
+  font-size: .67rem;
+  font-weight: 750;
 }
 
-.links-container {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.link-wrapper {
-  position: relative;
-  display: inline-flex;
-}
+.links-container { display: flex; flex-wrap: wrap; gap: 5px; }
+.link-wrapper { position: relative; display: inline-flex; max-width: 100%; }
 
 a.google-link,
 a.official-link {
-  display: inline-block;
-  padding: 7px 12px;
-  border-radius: var(--radius-pill);
-  text-decoration: none;
-  font-size: 0.88rem;
-  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  max-width: 100%;
+  padding: 3px 9px;
   border: 1px solid transparent;
+  border-radius: 7px;
+  font-size: .72rem;
+  font-weight: 700;
+  line-height: 1.2;
+  text-decoration: none;
 }
 
-a.google-link {
-  background-color: var(--primary-blue-light);
-  color: var(--primary-blue);
-}
-
+a.google-link { border-color: #d4e4ff; background: var(--blue-soft); color: #1458b8; }
+a.official-link { border-color: #cbeade; background: var(--green-soft); color: #07694f; }
 a.google-link:hover,
-a.google-link:focus-visible {
-  background-color: var(--primary-blue);
-  color: #fff;
-}
-
-a.official-link {
-  background-color: var(--primary-green-light);
-  color: var(--primary-green);
-}
-
+a.google-link:focus-visible { border-color: var(--blue); background: var(--blue); color: #fff; }
 a.official-link:hover,
-a.official-link:focus-visible {
-  background-color: var(--primary-green);
-  color: #fff;
-}
+a.official-link:focus-visible { border-color: var(--green); background: var(--green); color: #fff; }
 
 .remove-link {
   position: absolute;
-  top: -8px;
-  right: -8px;
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  background-color: var(--accent-red);
-  color: #fff;
-  border: 2px solid #fff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  box-shadow: var(--shadow-sm);
-  z-index: 10;
+  top: -7px;
+  right: -7px;
+  z-index: 2;
+  display: none;
+  width: 21px;
+  height: 21px;
   padding: 0;
-  opacity: 0;
-  visibility: hidden;
-  transform: scale(0.85);
+  place-items: center;
+  border: 2px solid #fff;
+  border-radius: 50%;
+  background: var(--red);
+  color: #fff;
+  box-shadow: var(--shadow-soft);
+  cursor: pointer;
 }
 
-body.editing .remove-link {
-  opacity: 1;
-  visibility: visible;
-  transform: scale(1);
-}
-
-.remove-link:hover {
-  background-color: var(--accent-red-hover);
-}
+body.editing .remove-link { display: grid; }
 
 .add-link-form {
   display: grid;
-  gap: 10px;
   width: 100%;
-  margin-top: 12px;
-  padding: 12px;
-  background: var(--bg-muted);
-  border: 1px dashed var(--border-color);
-  border-radius: 12px;
+  gap: 7px;
+  margin-top: 7px;
+  padding: 9px;
+  border: 1px dashed #b6c3cf;
+  border-radius: 9px;
+  background: var(--surface-soft);
 }
 
-.form-row {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
+.form-row { display: flex; flex-wrap: wrap; gap: 7px; }
 .add-link-form input,
-.add-link-form select {
-  flex: 1;
-  min-width: 180px;
-  padding: 10px 12px;
-  border-radius: 10px;
-  border: 1px solid var(--border-color);
-  background: #fff;
-}
-
-.form-actions {
-  display: flex;
-  gap: 10px;
-}
-
+.add-link-form select { flex: 1; min-width: 130px; height: 34px; padding: 0 9px; border: 1px solid var(--line); border-radius: 7px; background: #fff; color: var(--ink); font-size: .76rem; }
+.form-actions { display: flex; gap: 6px; }
 .add-btn,
-.reset-btn {
-  border: none;
-  cursor: pointer;
-  border-radius: var(--radius-pill);
-  padding: 10px 14px;
-  font-weight: 700;
-}
-
-.add-btn {
-  background: var(--primary-blue);
-  color: #fff;
-}
-
-.reset-btn {
-  background: #fff;
-  color: var(--dark-text);
-  border: 1px solid var(--border-color);
-}
+.reset-btn { min-height: 34px; padding: 0 11px; border: 1px solid var(--line); border-radius: 7px; font-size: .75rem; font-weight: 750; cursor: pointer; }
+.add-btn { border-color: var(--blue); background: var(--blue); color: #fff; }
+.reset-btn { background: #fff; color: var(--ink); }
 
 .empty-category-msg,
-.no-results {
-  color: var(--light-text);
-  background: var(--bg-muted);
-  border: 1px dashed var(--border-color);
-  border-radius: var(--radius-md);
-  padding: 14px 16px;
-}
+.no-results { padding: 14px; border: 1px dashed var(--line); border-radius: var(--radius-sm); background: var(--surface-soft); color: var(--ink-soft); font-size: .84rem; }
+.no-results { display: none; margin-bottom: 12px; }
+.no-results.visible { display: block; }
 
-.no-results {
-  display: none;
-  margin-top: 12px;
-}
-
-.no-results.visible {
-  display: block;
-}
-
-.footer {
-  margin-top: 24px;
-  padding-top: 16px;
-  border-top: 1px solid var(--border-color);
-  color: var(--light-text);
-  display: grid;
-  gap: 8px;
-}
-
-.last-updated {
-  font-weight: 700;
-  color: var(--dark-text);
-}
+.footer { display: flex; align-items: center; justify-content: space-between; gap: 20px; margin: 10px 22px 0; padding: 16px 0 20px; border-top: 1px solid var(--line); color: var(--ink-soft); font-size: .74rem; }
+.footer p { max-width: 760px; }
+.last-updated { color: var(--navy); font-weight: 750; white-space: nowrap; }
 
 #back-to-top-btn {
   position: fixed;
   right: 20px;
   bottom: 20px;
-  border: none;
-  background: var(--dark-text);
+  z-index: 90;
+  padding: 10px 14px;
+  border: 0;
+  border-radius: var(--pill);
+  background: var(--navy);
   color: #fff;
-  padding: 12px 16px;
-  border-radius: var(--radius-pill);
-  box-shadow: var(--shadow-lg);
-  cursor: pointer;
+  box-shadow: var(--shadow);
+  font-size: .75rem;
+  font-weight: 750;
   opacity: 0;
   pointer-events: none;
+  transform: translateY(8px);
 }
 
-#back-to-top-btn.visible {
-  opacity: 1;
-  pointer-events: auto;
-}
+#back-to-top-btn.visible { opacity: 1; pointer-events: auto; transform: none; }
 
 #toast-notification {
   position: fixed;
   left: 50%;
   bottom: 24px;
-  transform: translateX(-50%) translateY(12px);
-  background: var(--dark-text);
+  z-index: 200;
+  padding: 10px 15px;
+  border-radius: var(--pill);
+  background: var(--navy);
   color: #fff;
-  padding: 12px 16px;
-  border-radius: var(--radius-pill);
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--shadow);
+  font-size: .8rem;
+  font-weight: 700;
   opacity: 0;
   pointer-events: none;
+  transform: translate(-50%, 10px);
 }
 
-#toast-notification.show {
-  opacity: 1;
-  transform: translateX(-50%) translateY(0);
+#toast-notification.show { opacity: 1; transform: translate(-50%, 0); }
+#toast-notification.error { background: var(--red); }
+
+:focus-visible { outline: 3px solid rgba(23, 105, 224, .3); outline-offset: 2px; }
+
+@media (max-width: 1180px) {
+  header { padding-right: 80px; }
+  .hero { max-width: 820px; }
+  .status-bar { position: static; margin-top: 18px; }
+  .command-bar { grid-template-columns: 1fr; gap: 8px; }
+  .search-panel { justify-content: space-between; }
+  .link-labels { justify-content: flex-start; }
 }
 
-#toast-notification.error {
-  background: var(--accent-red);
+@media (max-width: 900px) {
+  body { padding: 10px; }
+  .container { border-radius: 16px; }
+  header { min-height: 0; padding: 26px 72px 22px; }
+  .home-button { left: 18px; top: 20px; }
+  .header-controls { right: 18px; top: 20px; }
+  .subtitle { max-width: 640px; }
+  .status-card { min-width: 0; }
+  tbody { grid-template-columns: 1fr; }
+  .command-bar { padding: 10px 14px; }
+  main { padding: 14px; }
+  .footer { margin-inline: 14px; }
 }
 
-@media (max-width: 860px) {
-  .container {
-    padding: 18px;
-  }
-
-  header {
-    margin: -18px -18px 20px;
-    padding: 18px;
-  }
-
-  .status-bar {
-    grid-template-columns: 1fr;
-  }
-
-  .search-row {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  table,
-  thead,
-  tbody,
-  th,
-  td,
-  tr {
-    display: block;
-  }
-
-  thead {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-  }
-
-  tbody tr {
-    margin-bottom: 14px;
-    border-radius: var(--radius-md);
-    overflow: hidden;
-  }
-
-  td {
-    border-left: 1px solid var(--border-color);
-    border-right: 1px solid var(--border-color);
-  }
-
-  td:first-child,
-  td:last-child {
-    width: 100%;
-    border-radius: 0;
-  }
-
-  td:first-child {
-    border-top-left-radius: var(--radius-md);
-    border-top-right-radius: var(--radius-md);
-  }
-
-  td:last-child {
-    border-bottom-left-radius: var(--radius-md);
-    border-bottom-right-radius: var(--radius-md);
-  }
+@media (max-width: 680px) {
+  body { padding: 0; background: #fff; }
+  .container { border: 0; border-radius: 0; box-shadow: none; }
+  header { padding: 68px 18px 20px; }
+  .hero { text-align: left; }
+  h1 { font-size: 2rem; }
+  .subtitle { font-size: .85rem; }
+  .status-bar { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-top: 15px; }
+  .status-card { padding: 8px 9px; }
+  .status-label { font-size: .58rem; }
+  .status-value { font-size: .72rem; }
+  .command-bar { position: sticky; gap: 8px; padding: 9px 10px; }
+  .search-panel { display: grid; grid-template-columns: 1fr; gap: 7px; }
+  .search-row { width: 100%; }
+  .filters { width: 100%; overflow-x: auto; padding-bottom: 1px; scrollbar-width: none; }
+  .filters::-webkit-scrollbar { display: none; }
+  .filter-chip { flex: 0 0 auto; }
+  .link-labels { gap: 8px; }
+  .link-label { font-size: .65rem; }
+  .edit-toggle { margin-left: auto; }
+  main { padding: 10px; }
+  tbody { gap: 8px; }
+  tbody tr { grid-template-columns: 1fr; }
+  td { padding: 9px 10px; }
+  td:first-child { border-right: 0; border-bottom: 1px solid var(--line); }
+  .province-name { min-height: 23px; display: flex; align-items: center; }
+  .links-container { gap: 4px; }
+  a.google-link,
+  a.official-link { min-height: 30px; font-size: .7rem; }
+  .footer { display: grid; gap: 8px; margin: 5px 10px 0; padding-bottom: 70px; }
+  .last-updated { white-space: normal; }
 }
 
-@media (max-width: 640px) {
-  body {
-    padding: 10px;
-  }
-
-  .header-controls,
-  .home-button {
-    position: static;
-  }
-
-  header {
-    padding-top: 16px;
-  }
-
-  .hero {
-    margin-top: 4px;
-  }
-
-  .link-labels,
-  .filters,
-  .form-row,
-  .form-actions {
-    width: 100%;
-  }
-
-  .filters {
-    justify-content: flex-start;
-  }
-
-  .filter-chip,
-  .edit-toggle,
-  .language-toggle {
-    width: auto;
-  }
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { scroll-behavior: auto !important; transition-duration: .01ms !important; }
 }


### PR DESCRIPTION
## Summary\n- replace the tall sticky header and table-style list with a compact masthead, sticky command bar, and responsive jurisdiction cards\n- reduce scrolling with a two-column desktop layout while retaining touch-friendly mobile presentation\n- preserve English and French content, all existing URLs, search/filter controls, and custom-link editing\n- retain accessible link labels when links are recreated from local storage\n\n## Verification\n- confirmed all 82 href values in each language are preserved exactly and in their original order\n- exercised English and French layouts in Chromium at desktop and mobile viewport sizes\n- verified search result counts, filters, edit mode, language navigation, and absence of horizontal overflow\n- confirmed no browser console errors\n- ran the JavaScript syntax check and Git whitespace validation